### PR TITLE
(#9) go.mod: Update module path to match VCS path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/choria-io/go-external-agent
+module github.com/choria-io/go-external
 
 go 1.13


### PR DESCRIPTION
Resolves #9 

Since the repository has been renamed `go-external` from `go-external-agent`, the module path should match this.